### PR TITLE
target を es2021 に変更

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2021",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
### 関連 Issue

[ES5 からの脱出 · Issue \#42 · Atis9/nyantech\.com](https://github.com/Atis9/nyantech.com/issues/42)

### 内容

* `compilerOptions` の `target` を `es2021` にした