### PR TITLE
フォントに 'BIZ UDPGothic' を指定した

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,5 +1,6 @@
 import { AppProps } from 'next/app';
 import '@primer/css/index.scss';
+import '../styles/globals.scss';
 
 function MyApp({ Component, pageProps }: AppProps) {
   return <Component {...pageProps} />;

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -1,0 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=BIZ+UDPGothic&display=swap');
+
+body {
+  font-family: 'BIZ UDPGothic', sans-serif;
+}


### PR DESCRIPTION
**関連 Issue**

#53

**概要**

フォント指定を追加した

**詳細**

* フォントに 'BIZ UDPGothic' を指定した

**関連資料**

[BIZ UDPGothic \- Google Fonts](https://fonts.google.com/specimen/BIZ+UDPGothic)