### PR TITLE
markdown-body の font-family を上書きした

### DIFF
--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -3,3 +3,7 @@
 body {
   font-family: 'BIZ UDPGothic', sans-serif;
 }
+
+.markdown-body {
+  font-family: 'BIZ UDPGothic', sans-serif;
+}


### PR DESCRIPTION
**関連 Issue**

#53 

**概要**

font 指定を追加

**詳細**

* `markdown-body` の `font-family` を上書きした

**関連資料**
